### PR TITLE
Fix duplicates ('Cav3.3' and 'Sleep spindle') in additionsToOntologies.csv

### DIFF
--- a/nat/data/additionsToOntologies.csv
+++ b/nat/data/additionsToOntologies.csv
@@ -28,8 +28,8 @@ BBP_nlx_0021;Thalamic reticular nucleus cell - non-GABAergic;;"NIFCELL:nifext_45
 BBP_nlx_0022;Thalamic reticular nucleus cell - GABAergic;;"NIFCELL:nifext_45";""
 BBP_nlx_0023;Chinese hamster ovary cell;Also known as CHO cell.;"NIFMOL:nifext_2506";""
 
-BBP_nlx_0025;Sleep spindle;;;
-BBP_nlx_0026;Cav3.3;;;
+BBP_nlx_0033;Sleep spindle;"Burst of 11-16 Hz transient (0.5-2.0 s duration) activity typically observed on EEG during non-rapid eye movement sleep stage (NREM) 2.";"";""
+BBP_nlx_0026;Cav3.3;"Calcium channel Cav3.3.";"NIFMOL:nifext_2653";""
 
 BBP_nlx_0028;Thalamic reticular nucleus - medial tier;;"NIFGA:birnlex_1721";""
 BBP_nlx_0029;Thalamic reticular nucleus - central tier;;"NIFGA:birnlex_1721";""
@@ -45,8 +45,6 @@ BBP_nlx_0032;ventro-lateral/posterior thalamic complex;This region is the union 
 
 
 # Various terms used in the past through Neurolex that are not available anymore in Knowledge-space
-BBP_nlx_0021;Sleep spindle;"Burst of 11-16 Hz transient (0.5-2.0 s duration) activity typically observed on EEG during non-rapid eye movement sleep stage (NREM) 2.";"";""
-BBP_nlx_0022;Cav3.3;"Calcium channel Cav3.3.";"NIFMOL:nifext_2653";""
 nlx_57050;Brain region role;Role assigned to particular brain regions according to some criteria that distinguishes among different territories, e.g., association cortex, thalamic relay nucleus;"BFO:0000023";""
 Nlx_137281;Thalamic relay nucleus;A thalamic nucleus that receives a well-defined subcortical input as part of one or the sensory or motor pathways whose cells project to the middle layers of a restricted region of cerebral cortex and receive a reciprocal projection from the same region of cortex. This designation is based on an organizational scheme proposed by Jones (1985), although it is recognized to be an oversimplification of thalamic organization. (adapted from Paxinos, The Rat Nervous System, 2nd ed, Academic Press, 1995.;nlx_57050;""
 nlx_151963;Higher order thalamic relay nucleus;A thalamic relay nucleus that relays information from layer 5 of one cortical area to another, as distinguished from a first order relay nucleus that transmits subcortical information to the cortex, as proposed by Sherman and Guillery. All thalamic relays receive a layer-6 modulatory input from cortex, but higher-order relays in addition receive a layer-5 driver input, e.g., pulvinar nucleus.;Nlx_137281;""


### PR DESCRIPTION
BBP_nlx_0021 was wrongly associated to both 'Thalamic reticular nucleus cell - non-GABAergic' and to 'Sleep spindle'. BBP_nlx_0022 was wrongly associated to both 'Thalamic reticular nucleus cell - GABAergic' and to 'Cav3.3'.

'Sleep spindle' was wrongly associated to both BBP_nlx_0021 and BBP_nlx_0025. 'Cav3.3' was wrongly associated to both BBP_nlx_0022 and BBP_nlx_0026.

Wrong mentions were corrected in the annotations by the following commits:
- https://github.com/BlueBrain/corpus-thalamus/commit/f2f2752e7406632a2998eaffac744b6d1a460f43
- https://github.com/BlueBrain/corpus-thalamus/commit/2d427b456f20e9bd9f94e8f5da2ecc441ebb29c8